### PR TITLE
Allow passing arguments to <options> methods

### DIFF
--- a/src/app/code/community/FireGento/GridControl/Model/Processor.php
+++ b/src/app/code/community/FireGento/GridControl/Model/Processor.php
@@ -110,9 +110,15 @@ class FireGento_GridControl_Model_Processor
                 if (strpos((string) $attribute, '::') !== false) {
                     list($_module, $_method) = explode('::', (string) $attribute);
                     $_module = Mage::getSingleton($_module);
+                    if ($_args = strstr($_method, '(')) {
+                        $_method = str_replace($_args, '', $_method);
+                        $_args = array_map('trim', explode(',', str_replace(array('(', ')', '\'', '"'), '', $_args)));
+                    } else {
+                        $_args = array();
+                    }
                     $_call = array($_module, $_method);
                     if (is_callable($_call)) {
-                        $columnConfig['options'] = call_user_func($_call);
+                        $columnConfig['options'] = call_user_func($_call, $_args);
                         continue;
                     }
                 }


### PR DESCRIPTION
Allows you to write a method like this when working with dropdown EAV attributes

```php
<?php

class Mpchadwick_GridControl_Model_Utility
{
    public function getDropdownAttributeLabelOptionArray($attribute)
    {
        $attribute = Mage::getModel('eav/config')->getAttribute('catalog_product', $attribute);
        $options = $attribute->getSource()->getAllOptions(false);

        $map = [];
        foreach ($options as $option) {
            $map[$option['value']] = $option['label'];
        }

        return $map;
    }
}
```

Then you can re-use it whenever adding a dropdown attribute

```xml
<?xml version="1.0"?>
<gridcontrol>
    <grids>
        <productGrid>
           <manufacturer>
                <add>
                    <header>Brand</header>
                    <type>options</type>
                    <index>manufacturer</index>
                    <options>mpchadwick_gridconfig/utility::getDropdownAttributeLabelOptionArray('manufacturer')</options>
                </add>
                <after>name</after>
            </manufacturer>
        </productGrid>
    </grids>
</gridcontrol>
```

There might be other use cases I'm not thinking of...