### PR TITLE
Add a default method for fetching dropdown eav attribute options

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ XML Syntax
                 </add>
             </column>
 
+            <manufacturer>
+                <add>
+                    <header>Manufacturer</header>
+                    <type>options</type>
+                    <index>manufacturer</index>
+                    <options>firegento_gridcontrol/utility::getDropdownAttributeLabelOptionArray(manufacturer)</options>
+                </add>
+            </manufacturer>
+
             <selecttest>
                 <add>
                     <header>Status Column</header>

--- a/src/app/code/community/FireGento/GridControl/Model/Utility.php
+++ b/src/app/code/community/FireGento/GridControl/Model/Utility.php
@@ -1,0 +1,24 @@
+<?php
+
+class FireGento_GridControl_Model_Utility
+{
+    public function getDropdownAttributeLabelOptionArray($attribute)
+    {
+        $map = array();
+
+        if (is_array($attribute)) {
+            $attribute = reset($attribute);
+        }
+
+        if ($attribute) {
+            $attribute = Mage::getModel('eav/config')->getAttribute('catalog_product', $attribute);
+            $options = $attribute->getSource()->getAllOptions(false);
+
+            foreach ($options as $option) {
+                $map[$option['value']] = $option['label'];
+            }
+        }
+
+        return $map;
+    }
+}


### PR DESCRIPTION
Based on https://github.com/magento-hackathon/GridControl/pull/19.

This makes it easier to add custom dropdown attributes to the product grid.