### PR TITLE
Reordering clash with BL_CustomGrid

### DIFF
--- a/src/app/code/community/FireGento/GridControl/Model/Processor.php
+++ b/src/app/code/community/FireGento/GridControl/Model/Processor.php
@@ -43,7 +43,7 @@ class FireGento_GridControl_Model_Processor
         
         // Clash with Bl_CustomGrid and ordering of columns via its admin interface
         // do not order if BL_CustomGrid is enabled
-        if (Mage::helper('core')->isModuleEnabled('BL_CustomGrid')){
+        if (!Mage::helper('core')->isModuleEnabled('BL_CustomGrid')){
             $block->sortColumnsByOrder();
         }
 

--- a/src/app/code/community/FireGento/GridControl/Model/Processor.php
+++ b/src/app/code/community/FireGento/GridControl/Model/Processor.php
@@ -40,7 +40,12 @@ class FireGento_GridControl_Model_Processor
         }
 
         // resort columns
-        $block->sortColumnsByOrder();
+        
+        // Clash with Bl_CustomGrid and ordering of columns via its admin interface
+        // do not order if BL_CustomGrid is enabled
+        if (Mage::helper('core')->isModuleEnabled('BL_CustomGrid')){
+            $block->sortColumnsByOrder();
+        }
 
         // register current block, needed to extend the collection in FireGento_GridControl_Model_Observer
         Mage::register('firegento_gridcontrol_current_block', $block);


### PR DESCRIPTION
I have found that the re-ordering of the grid columns clash with the popular BL_CustomGrid module, which orders columns via an admin panel option.

This checks for that module, and if enabled, skips ordering.