### PR TITLE
Support to updateColumn (updates an existing column)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Features
 - move columns
 - add new attributes
 - join new attributes
+- update columns
 
 Todo
 -----
@@ -51,6 +52,17 @@ XML Syntax
                     <joinField>qty|cataloginventory/stock_item|qty|product_id=entity_id|{{table}}.stock_id=1|left</joinField>
                 </add>
             </column>
+
+            <existingColumn>
+                <updateColumn>
+                    <attributeToUpdate>newValue</attributeToUpdate>
+                </updateColumn>
+            </existingColumn>
+            <real_order_id>
+                <updateColumn>
+                    <filter_index>main_table.increment_id</filter_index>
+                </updateColumn>
+            </real_order_id>
 
             <manufacturer>
                 <add>

--- a/src/app/code/community/FireGento/GridControl/Model/Processor.php
+++ b/src/app/code/community/FireGento/GridControl/Model/Processor.php
@@ -230,4 +230,26 @@ class FireGento_GridControl_Model_Processor
         $this->setGridProtectedPropertyValue($grid, $columnsPropertyName, $columns);
         $this->setGridProtectedPropertyValue($grid, $lastColumnIdPropertyName, $lastColumnId);
     }
+
+    /**
+     * Updates an existing column
+     * Example: <status><updateColumn><filter_index>main_table.status</filter_index></updateColumn></status>
+     * @param array $params
+     */
+    protected function _updateColumnAction($params)
+    {
+        $columnConfig = array();
+        $blockId = $params->getBlock()->getId();
+        /**
+         * @var FireGento_GridControl_Model_Config $config
+         */
+        $config = Mage::getSingleton('firegento_gridcontrol/config');
+
+        foreach ($params->getAction()->children() as $attribute) {
+//            $params->getBlock()->getColumn('status')->setData('index', 'main_table.status')
+            $params->getBlock()->getColumn($params->getColumn()->getName())->setData(
+                $attribute->getName(), (string)$attribute
+            );
+        }
+    }
 }


### PR DESCRIPTION
Now we can update a column, and it could also be used as a workaround to #17 .

For example:

```xml
<real_order_id>
    <updateColumn>
        <filter_index>main_table.increment_id</filter_index>
    </updateColumn>
</real_order_id>

<status>
    <updateColumn>
        <filter_index>main_table.status</filter_index>
    </updateColumn>
</status>
```

This way when adding a join to a table that mess with our existing columns, we can specify different filter_index to that column.